### PR TITLE
Hide empty tags

### DIFF
--- a/templates/partials/taxonomylist.html.twig
+++ b/templates/partials/taxonomylist.html.twig
@@ -4,9 +4,9 @@
 
 <span class="tags">
     {% for tax,value in taxlist[taxonomy] %}
-
-        <a href="{{ base_url }}/{{ taxonomy }}{{ config.system.param_sep }}{{ tax|e('url') }}">{{ tax }}</a>
-
+        {% if tax|length %}
+            <a href="{{ base_url }}/{{ taxonomy }}{{ config.system.param_sep }}{{ tax|e('url') }}">{{ tax }}</a>
+        {% endif %}
     {% endfor %}
 </span>
 {% endif %}


### PR DESCRIPTION
Only show tags with valid values. Hide empty ('') tags. See also Issue #6