### PR TITLE
Update taxonomylist-childpages.html.twig

### DIFF
--- a/templates/partials/taxonomylist-childpages.html.twig
+++ b/templates/partials/taxonomylist-childpages.html.twig
@@ -3,7 +3,7 @@
 {% if taxlist %}
 <span class="tags">
     {% for tax,value in taxlist[taxonomy] %}
-        {% set active = uri.param(taxonomy) == tax ? 'active' : '' %}
+        {% set active = uri.param(taxonomy) == tax|lower ? 'active' : '' %}
         <a class="{{ active }}" href="{{ base_url }}/{{ taxonomy }}{{ config.system.param_sep }}{{ tax }}">{{ tax }}</a>
     {% endfor %}
 </span>


### PR DESCRIPTION
As of GRAV 1.3.8 uri.param returns a lowercase string, even if the taxonomy has uppercase letters