### PR TITLE
Resolved issue with children_only option showing unpublished pages

### DIFF
--- a/classes/taxonomylist.php
+++ b/classes/taxonomylist.php
@@ -33,7 +33,7 @@ class Taxonomylist
     {
         $current = Grav::instance()['page'];
         $taxonomies = [];
-        foreach ($current->children() as $child) {
+        foreach ($current->children()->published() as $child) {
             foreach($this->build($child->taxonomy()) as $taxonomyName => $taxonomyValue) {
                 if (!isset($taxonomies[$taxonomyName])) {
                     $taxonomies[$taxonomyName] = $taxonomyValue;


### PR DESCRIPTION
getChildPages() previously included all child pages of the current one to build the taxonomy array - now it only includes published pages.