### PR TITLE
adding page descendants taxonomies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,26 @@ The plugin provides a Twig template that you need to include in your theme. Some
 
 Where `my_url` is the URL to link to where the collection can be filtered (e.g. `/blog`) and the `taxonomy` points to a specific taxonomy type to display (e.g. `tag`). This will display all tags throughout your site
 
-## Child-only Include
+## Child-only or descendants Include
 
-You can also include pass an optional parameter that will show taxonomy for child-pages only:
+You can also include pass an optional parameter that will show taxonomy for child-pages only if set to true, or for all page's descendants if set to false:
 
+### Show only page first level childs taxonomy
 ```twig
+//children_only set to true
 {% include 'partials/taxonomylist.html.twig' with {base_url: my_url, taxonomy: 'tag', children_only: true} %}
+```
+### Show all page's descendants taxonomies
+```twig
+//children_only set to false
+{% include 'partials/taxonomylist.html.twig' with {base_url: my_url, taxonomy: 'tag', children_only: false} %}
+```
+
+### Show all site wide taxonomies 
+```twig
+//children_only not set
+{% include 'partials/taxonomylist.html.twig' with {base_url: my_url, taxonomy: 'tag'} %}
+
 ```
 
 > NOTE: If you want to see this plugin in action, have a look at our [Blog Site Skeleton](http://github.com/grav/grav-skeleton-blog-site/archive/master.zip)

--- a/classes/taxonomylist.php
+++ b/classes/taxonomylist.php
@@ -26,19 +26,25 @@ class Taxonomylist
 
     /**
      * Get taxonomy list with only tags of the child pages.
-     *
+     * @param type $child_only // will recurs through all descedants if set to false
+     * @param type $current // page to start with
+     * @param array $taxonomies //array to feed with tags
      * @return array
      */
-    public function getChildPagesTags()
+    public function getChildPagesTags( $child_only=true, $current=null , array &$taxonomies=[] )
     {
-        $current = Grav::instance()['page'];
-        $taxonomies = [];
-        foreach ($current->children()->published() as $child) {
+        if(is_null($current))
+        {
+            $current = Grav::instance()['page'];
+        }
+        foreach ( $current->children()->published() as $child) 
+        {
             foreach($this->build($child->taxonomy()) as $taxonomyName => $taxonomyValue) {
                 if (!isset($taxonomies[$taxonomyName])) {
                     $taxonomies[$taxonomyName] = $taxonomyValue;
                 } else {
                     foreach ($taxonomyValue as $value => $count) {
+                        
                         if (!isset($taxonomies[$taxonomyName][$value])) {
                             $taxonomies[$taxonomyName][$value] = $count;
                         } else {
@@ -47,8 +53,10 @@ class Taxonomylist
                     }
                 }
             }
+           // recurse
+            if(!$child_only) $this->getChildPagesTags($child_only, $child, $taxonomies);
         }
-
+        array_multisort( $taxonomies );
         return $taxonomies;
     }
 

--- a/templates/partials/taxonomylist.html.twig
+++ b/templates/partials/taxonomylist.html.twig
@@ -1,4 +1,4 @@
-{% set taxlist = children_only is defined ? taxonomylist.getChildPagesTags() : taxonomylist.get() %}
+{% set taxlist = children_only is defined ? taxonomylist.getChildPagesTags(children_only) : taxonomylist.get() %}
 
 {% if taxlist %}
 <span class="tags">


### PR DESCRIPTION
making getChildPagesTags recursive and backwards compatible to allow user to choose between 
- site wide taxo
- page's first level childs taxo
- page's all descendants taxo