### PR TITLE
Specify the page from which to get the child tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ You can also include pass an optional parameter that will show taxonomy for chil
 {% include 'partials/taxonomylist.html.twig' with {base_url: my_url, taxonomy: 'tag', children_only: true} %}
 ```
 
+When using `children_only`, another optional parameter may be used to specify the page to use:
+
+```twig
+{% include 'partials/taxonomylist.html.twig' with {base_url: my_url, taxonomy: 'tag', children_only: true, of_page:page.parent} %}
+```
+
+
 > NOTE: If you want to see this plugin in action, have a look at our [Blog Site Skeleton](https://github.com/getgrav/grav-skeleton-blog-site/archive/master.zip)
 
 

--- a/classes/taxonomylist.php
+++ b/classes/taxonomylist.php
@@ -32,10 +32,13 @@ class Taxonomylist
      *
      * @return array
      */
-    public function getChildPagesTags()
+    public function getChildPagesTags(PageInterface $current = null)
     {
         /** @var PageInterface $current */
-        $current = Grav::instance()['page'];
+        if (null === $current) {
+            $current = Grav::instance()['page'];
+        }
+
         $taxonomies = [];
         foreach ($current->children()->published() as $child) {
             if (!$child->isPage()) {

--- a/templates/partials/taxonomylist.html.twig
+++ b/templates/partials/taxonomylist.html.twig
@@ -1,4 +1,4 @@
-{% set taxlist = children_only is defined ? taxonomylist.getChildPagesTags() : taxonomylist.get() %}
+{% set taxlist = children_only is defined ? taxonomylist.getChildPagesTags(of_page) : taxonomylist.get() %}
 
 {% if taxlist %}
 <span class="tags">


### PR DESCRIPTION
Hello,

A very small suggestion to give the possibility to specify which page’s child tags one wants.
- This is very useful when many "blogs" are used on a site to have **contextualized tags**.
- Fully **backward compatible**.
- No fuss, no clutter, **a single new optional parameter** when calling the template. _(I guess one could change its name; I do not know if there are naming standards.)_
- `README.md` has been updated to add the information.

Kind regards.